### PR TITLE
Fix moab build if not building cgm

### DIFF
--- a/setup/build.bash
+++ b/setup/build.bash
@@ -48,6 +48,7 @@ function get_dependencies() {
   if [[ " ${packages[@]} " =~ " meshkit " ]]; then
     packages+=(gcc)
     packages+=(hdf5)
+    packages+=(cgm)
     packages+=(moab)
   fi
   if [[ " ${packages[@]} " =~ " moab " ]]; then

--- a/setup/build_funcs.bash
+++ b/setup/build_funcs.bash
@@ -471,13 +471,13 @@ function build_moab() {
   config_string=
   config_string+=" "--enable-dagmc
   config_string+=" "--enable-fbigeom
-  config_string+=" "--enable-irel
   config_string+=" "--enable-optimize
   config_string+=" "--enable-shared
   config_string+=" "--disable-debug
   config_string+=" "--with-hdf5=$install_dir/hdf5
   if [[ " ${packages[@]} " =~ " cgm " ]]; then
     config_string+=" "--with-cgm=$install_dir/cgm
+    config_string+=" "--enable-irel
   fi
   config_string+=" "--prefix=$install_dir/$folder
 


### PR DESCRIPTION
This fixes a bug where the MOAB build would fail if you weren't also installing CGM.