### PR TITLE
Allowing averaging of multiple files.

### DIFF
--- a/combine/meshtal_combine.py
+++ b/combine/meshtal_combine.py
@@ -663,11 +663,6 @@ def main():
         help()
         sys.exit(1) 
 
-    if avg >=0  and len(sys.argv) > 2:
-        print 'Error: Averaging only supported for 2 files'
-        help()
-        sys.exit(1)
-        
     meshfiles = sys.argv[filesNdx:]
     
     if streaming < 0:


### PR DESCRIPTION
The script does handle averaging of multiple meshtal files correctly by tracking the number of histories. This PR allows for multiple meshtal files to be averaged. 